### PR TITLE
FortiOS 7.0 compatibility

### DIFF
--- a/-inputs.tf
+++ b/-inputs.tf
@@ -21,3 +21,9 @@ variable "vpn_mappings" {
     })
   }))
 }
+
+variable "create_system_interfaces" {
+  description = "A boolean to specify if a system interface should be explicitly created for IPsec site-to-site VPN. As of FortiOS 7.0.0, a valid system interface is created automatically when a phase1 interface is created."
+  type = bool
+  default = false
+}

--- a/-outputs.tf
+++ b/-outputs.tf
@@ -1,5 +1,4 @@
 output "local_tunnel_ips" {
-//TODO: add logic to output tunnel IPs if no system interfaces are created by terraform.
   description = "A map of the tunnel interface => IPs to dynamically add to OSPF, FW rules, etc."
   value = {
     for interface in merge(fortios_system_interface.this, data.fortios_system_interface.this) :

--- a/-outputs.tf
+++ b/-outputs.tf
@@ -1,11 +1,8 @@
 output "local_tunnel_ips" {
 //TODO: add logic to output tunnel IPs if no system interfaces are created by terraform.
   description = "A map of the tunnel interface => IPs to dynamically add to OSPF, FW rules, etc."
-  value =
-    var.create_system_interfaces == true ?
-      for interface in fortios_system_interface.this :
-      interface.name => interface.ip
-    :
-      for interface in data.fortios_system_interface.this :
-      interface.name => interface.ip
+  value = {
+    for interface in merge(fortios_system_interface.this, data.fortios_system_interface.this) :
+    interface.name => interface.ip
+  }
 }

--- a/-outputs.tf
+++ b/-outputs.tf
@@ -1,13 +1,12 @@
 output "local_tunnel_ips" {
 //TODO: add logic to output tunnel IPs if no system interfaces are created by terraform.
   description = "A map of the tunnel interface => IPs to dynamically add to OSPF, FW rules, etc."
-  value = var.create_system_interfaces == true ?
-  {
-    for interface in fortios_system_interface.this :
-    interface.name => interface.ip
-  } :
-  {
-    for interface in data.fortios_system_interface.this :
-    interface.name => interface.ip
+  value = {
+    var.create_system_interfaces == true ?
+      for interface in fortios_system_interface.this :
+      interface.name => interface.ip
+    :
+      for interface in data.fortios_system_interface.this :
+      interface.name => interface.ip
   }
 }

--- a/-outputs.tf
+++ b/-outputs.tf
@@ -5,3 +5,11 @@ output "local_tunnel_ips" {
     interface.name => interface.ip
   }
 }
+
+output "local_tunnel_interfaces" {
+  description = "A map of the tunnel interface names to add to firewall policies."
+  value = {
+    for interface in fortios_vpnipsec_phase1interface.this :
+    interface.interface => interface.local_gw
+  }
+}

--- a/-outputs.tf
+++ b/-outputs.tf
@@ -1,4 +1,5 @@
 output "local_tunnel_ips" {
+//TODO: add logic to output tunnel IPs if no system interfaces are created by terraform.
   description = "A map of the tunnel interface => IPs to dynamically add to OSPF, FW rules, etc."
   value = {
     for interface in fortios_system_interface.this :

--- a/-outputs.tf
+++ b/-outputs.tf
@@ -1,12 +1,11 @@
 output "local_tunnel_ips" {
 //TODO: add logic to output tunnel IPs if no system interfaces are created by terraform.
   description = "A map of the tunnel interface => IPs to dynamically add to OSPF, FW rules, etc."
-  value = {
+  value =
     var.create_system_interfaces == true ?
       for interface in fortios_system_interface.this :
       interface.name => interface.ip
     :
       for interface in data.fortios_system_interface.this :
       interface.name => interface.ip
-  }
 }

--- a/-outputs.tf
+++ b/-outputs.tf
@@ -1,8 +1,13 @@
 output "local_tunnel_ips" {
 //TODO: add logic to output tunnel IPs if no system interfaces are created by terraform.
   description = "A map of the tunnel interface => IPs to dynamically add to OSPF, FW rules, etc."
-  value = {
+  value = var.create_system_interfaces == true ?
+  {
     for interface in fortios_system_interface.this :
+    interface.name => interface.ip
+  } :
+  {
+    for interface in data.fortios_system_interface.this :
     interface.name => interface.ip
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ locals {
     spoke = "hub"
   }
   # if create_system_interfaces is set to true then return vpn_mappings. Otherwise, return empty map.
-  system_interfaces = var.create_system_interfaces = true ? var.vpn_mappings : {}
+  system_interfaces = var.create_system_interfaces == true ? var.vpn_mappings : {}
 }
 
 resource "fortios_vpnipsec_phase1interface" "this" {

--- a/main.tf
+++ b/main.tf
@@ -11,9 +11,7 @@ locals {
     spoke = "hub"
   }
   # if create_system_interfaces is set to true then return vpn_mappings. Otherwise, return empty map.
-  system_interfaces = {
-    var.create_system_interfaces = true ? var.vpn_mappings : {}
-  }
+  system_interfaces = var.create_system_interfaces = true ? var.vpn_mappings : {}
 }
 
 resource "fortios_vpnipsec_phase1interface" "this" {
@@ -61,5 +59,5 @@ resource "fortios_system_interface" "this" {
 data "fortios_system_interface" "this" {
   for_each = var.create_system_interfaces == false ? fortios_vpnipsec_phase1interface.this : {}
 
-  filter = "name=${each.key.name}"
+  name = each.value.name
 }


### PR DESCRIPTION
As of FortiOS 7.0.0, system interfaces used by IPsec VPNs are created automatically when the relevant phase1 interface is configured. Modified module to make fortios_system_interface resource optional using the boolean var.create_system_interfaces.

Tested on a FortiGate 7.0.0 with var.create_system_interfaces set to 'false.' Please review HCL for code improvements.